### PR TITLE
Added "Copy Beatmap ID to clipboard" feature

### DIFF
--- a/osuTrainer/Commands/CopyBeatmapIdCommand.cs
+++ b/osuTrainer/Commands/CopyBeatmapIdCommand.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Input;
+using osuTrainer.ViewModels;
+
+namespace osuTrainer.Commands
+{
+    internal class CopyBeatmapIdCommand : ICommand
+    {
+        private readonly ScoresViewModel _viewModelBase;
+
+        
+        public CopyBeatmapIdCommand(ScoresViewModel viewModelBase)
+        {
+            _viewModelBase = viewModelBase;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return _viewModelBase.Scores.Count > 0;
+        }
+
+        public void Execute(object parameter)
+        {
+            Clipboard.SetText(_viewModelBase.SelectedScoreInfo.BeatmapId.ToString());
+        }
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+    }
+}

--- a/osuTrainer/ViewModels/OsuApiViewModel.cs
+++ b/osuTrainer/ViewModels/OsuApiViewModel.cs
@@ -32,6 +32,7 @@ namespace osuTrainer.ViewModels
             UpdateCommand = new UpdateCommand(this);
             OpenBeatmapLinkCommand = new OpenBeatmapLinkCommand(this);
             CopyLinkCommand = new CopyLinkCommand(this);
+            CopyBeatmapIdCommand = new CopyBeatmapIdCommand(this);
             DownloadCommand = new DownloadCommand(this);
             DownloadOdCommand = new DownloadOdCommand(this);
             DownloadBcCommand = new DownloadBcCommand(this);

--- a/osuTrainer/ViewModels/ScoresViewModel.cs
+++ b/osuTrainer/ViewModels/ScoresViewModel.cs
@@ -18,6 +18,7 @@ namespace osuTrainer.ViewModels
         private string _userid;
         public ICommand OpenBeatmapLinkCommand { get; set; }
         public ICommand CopyLinkCommand { get; set; }
+        public ICommand CopyBeatmapIdCommand { get; set; }
         public ICommand DownloadCommand { get; set; }
         public ICommand DownloadOdCommand { get; set; }
         public ICommand DownloadBcCommand { get; set; }

--- a/osuTrainer/Views/Scores.xaml
+++ b/osuTrainer/Views/Scores.xaml
@@ -281,6 +281,7 @@ Loaded="Scores_Loaded" Initialized="Scores_Initialized">
             <DataGrid.ContextMenu>
                 <ContextMenu Name="ScoresMenu">
                     <MenuItem Header="Open beatmap link" Command="{Binding OpenBeatmapLinkCommand}"/>
+                    <MenuItem Header="Copy Beatmap ID to clipboard" Command="{Binding CopyBeatmapIdCommand}"/>
                     <MenuItem Header="Copy link to clipboard" Command="{Binding CopyLinkCommand}"/>
                     <MenuItem Header="Download" Command="{Binding DownloadCommand}" />
                     <MenuItem Header="Download with osu!direct" Command="{Binding DownloadOdCommand}"/>

--- a/osuTrainer/osuTrainer.csproj
+++ b/osuTrainer/osuTrainer.csproj
@@ -74,6 +74,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Commands\CopyBeatmapIdCommand.cs" />
     <Compile Include="Commands\CopyLinkCommand.cs" />
     <Compile Include="Commands\DownloadBcCommand.cs" />
     <Compile Include="Commands\DownloadCommand.cs" />


### PR DESCRIPTION
Hello There :)

Great Tool that you've done there so far, I really like it :+1: 

For users without osu!Supporter it takes some effort to actually get to the recommended map, so I added the feature to copy the Beatmap ID, which can be pasted into osu!'s search bar to instantly jump to the right map with the right diff.

If you like this idea you could further add an option to copy the ID when double clicking the score instead of opening the Beatmap's URL.


I hope you like it :)

Greetings

timm0e